### PR TITLE
Reducing Ziggurats to just the last 3 levels

### DIFF
--- a/crawl-ref/source/dat/dlua/ziggurat.lua
+++ b/crawl-ref/source/dat/dlua/ziggurat.lua
@@ -58,6 +58,7 @@ end
 function ziggurat_build_level(e)
   if you.depth() == 1 then
     dgn.persist.ziggurat = { }
+    you.set_depth(25) -- warp ahead to level 25
     initialise_ziggurat(dgn.persist.ziggurat, portal)
   end
   local builder = zig().builder

--- a/crawl-ref/source/l-you.cc
+++ b/crawl-ref/source/l-you.cc
@@ -439,6 +439,19 @@ LUARET1(you_branch, string, level_id::current().describe(false, false).c_str())
  * @function depth
  */
 LUARET1(you_depth, number, you.depth)
+/*** Your current depth in that branch.
+ * @treturn int
+ * @tparam int x
+ * @function set_depth
+ */
+LUAFN(you_set_depth) 
+{
+    if (!lua_isnoneornil(ls, 1)) {
+        int new_depth = lua_tointeger(ls, 1);
+        you.depth = new_depth;
+    }
+    PLUARET(number, you.depth);
+}
 /*** What fraction of the branch you've gone into.
  * @treturn number
  * @function depth_fraction
@@ -1547,6 +1560,7 @@ static const struct luaL_reg you_dlib[] =
 { "change_species",     you_change_species },
 #ifdef WIZARD
 { "set_xl",             you_set_xl },
+{ "set_depth",          you_set_depth },
 #endif
 
 { nullptr, nullptr }


### PR DESCRIPTION
* Added a new d-lua function to allow **you.set_depth(number)** to change the player's current depth.
* Utilized the new function inside the Ziggurat initialization process to warp ahead to level 25 as it's being created.
